### PR TITLE
Add automatic deployment with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Install Kamal
+        run: gem install kamal
+
+      - name: Deploy with Kamal
+        env:
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: kamal deploy


### PR DESCRIPTION
## Summary
- GitHub Actionsを使用した自動デプロイメント機能を追加
- mainブランチへのマージ時に自動的にKamalでデプロイされるように設定

## Test plan
- [ ] GitHub Secretsに`KAMAL_REGISTRY_PASSWORD`と`RAILS_MASTER_KEY`が設定されていることを確認
- [ ] mainブランチにマージ後、GitHub Actionsでデプロイが正常に実行されることを確認